### PR TITLE
Add styled-components support

### DIFF
--- a/plugins.vim
+++ b/plugins.vim
@@ -77,6 +77,9 @@ Plug 'cespare/vim-toml'
 Plug 'jparise/vim-graphql'
 " watch out: https://github.com/sheerun/vim-polyglot/issues/236
 
+" Styled-components: syntax highlighting for CSS in JS template strings.
+Plug 'styled-components/vim-styled-components', { 'branch': 'main' }
+
 Plug 'chrisbra/Colorizer'
 
 " auto-pairs: Autoclose feature


### PR DESCRIPTION
This PR adds support for styled components.
This is the plugin: https://github.com/styled-components/vim-styled-components

Feel free to ignore this PR if you're not interested in `styled-components`.